### PR TITLE
chore(docs): integrate Swagger for API documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^10.0.0",
+        "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.3.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1"
       },
@@ -2033,6 +2035,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.1.tgz",
@@ -2498,6 +2506,21 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.0.tgz",
+      "integrity": "sha512-hyhUMtVwlT+tavtPNyekl8iP0QTU1U6awKrgdOSxhMhp3TQMltx7hz2yqGTcARp+19zWPfgJudyxthuD3lPp/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.4.15",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.15.tgz",
@@ -2532,6 +2555,26 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -2580,6 +2623,39 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.2.tgz",
+      "integrity": "sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.17.14"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.15",
@@ -4167,7 +4243,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -5793,6 +5868,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
+      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -9554,7 +9656,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10053,7 +10154,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -12852,6 +12952,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+      "license": "Apache-2.0"
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.3.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,18 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { SharedModule } from './shared/shared.module';
 
 @Module({
-  imports: [],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: '.env',
+    }),
+    SharedModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/constants/env.constants.ts
+++ b/src/constants/env.constants.ts
@@ -1,0 +1,13 @@
+export enum ENV_CONSTANTS {
+  APP_PORT = 'APP_PORT',
+  NODE_ENV = 'NODE_ENV',
+  API_VERSION = 'API_VERSION',
+  ENABLE_DOCUMENTATION = 'ENABLE_DOCUMENTATION',
+  API_PREFIX = 'API_PREFIX',
+}
+
+export const ENV_CONSTANTS_VALUES = {
+  PRODUCTION: 'production',
+  DEVELOPMENT: 'development',
+  TEST: 'test',
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,28 @@
+import { VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import { type NestExpressApplication } from '@nestjs/platform-express';
 
 import { AppModule } from './app.module';
+import { setupSwagger } from './setup-swagger';
+import { ApiConfigService } from './shared/services/api-config.service';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  const configService = app.get(ApiConfigService);
+  app.enableVersioning({
+    type: VersioningType.URI,
+  });
+  app.setGlobalPrefix(configService.apiPrefix, {
+    exclude: ['/'],
+  });
+  if (configService.documentationEnabled) {
+    setupSwagger(app);
+  }
+  if (configService.isNotDevelopment) {
+    app.enableShutdownHooks();
+  }
+  await app.listen(configService.port);
 }
 
 void bootstrap();

--- a/src/setup-swagger.ts
+++ b/src/setup-swagger.ts
@@ -1,0 +1,16 @@
+import { type INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+import { ENV_CONSTANTS } from './constants/env.constants';
+
+export function setupSwagger(app: INestApplication) {
+  const options = new DocumentBuilder()
+    .setTitle('API')
+    .setDescription('API docs')
+    .setVersion(process.env[ENV_CONSTANTS.API_VERSION] ?? '1.0')
+    .addBearerAuth()
+    .build();
+
+  const document = SwaggerModule.createDocument(app, options);
+  SwaggerModule.setup('docs', app, document);
+}

--- a/src/shared/services/api-config.service.ts
+++ b/src/shared/services/api-config.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ENV_CONSTANTS,
+  ENV_CONSTANTS_VALUES,
+} from 'src/constants/env.constants';
+
+@Injectable()
+export class ApiConfigService {
+  constructor(private configService: ConfigService) {}
+
+  get isDevelopment(): boolean {
+    return this.nodeEnv === ENV_CONSTANTS_VALUES.DEVELOPMENT;
+  }
+  get isNotDevelopment(): boolean {
+    return !this.isDevelopment;
+  }
+
+  get isProduction(): boolean {
+    return this.nodeEnv === ENV_CONSTANTS_VALUES.PRODUCTION;
+  }
+
+  get isTest(): boolean {
+    return this.nodeEnv === ENV_CONSTANTS_VALUES.TEST;
+  }
+
+  private get nodeEnv(): string {
+    return (
+      this.configService.get(ENV_CONSTANTS.NODE_ENV) ??
+      ENV_CONSTANTS_VALUES.DEVELOPMENT
+    );
+  }
+
+  get port(): number {
+    return this.configService.get(ENV_CONSTANTS.APP_PORT) ?? 3000;
+  }
+
+  private getBoolean(key: string): boolean {
+    const value = this.get(key);
+    try {
+      return Boolean(value);
+    } catch {
+      throw new Error(`${key} environment variable is not a boolean`);
+    }
+  }
+  get documentationEnabled(): boolean {
+    return this.getBoolean(ENV_CONSTANTS.ENABLE_DOCUMENTATION);
+  }
+
+  private get(key: string): string {
+    const value = this.configService.get<string>(key);
+
+    if (value == null) {
+      throw new Error(`${key} environment variable does not set`);
+    }
+
+    return value;
+  }
+
+  get apiPrefix(): string {
+    return this.get(ENV_CONSTANTS.API_PREFIX);
+  }
+}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+
+import { ApiConfigService } from './services/api-config.service';
+
+@Global()
+@Module({
+  providers: [ApiConfigService],
+  exports: [ApiConfigService],
+})
+export class SharedModule {}


### PR DESCRIPTION
This PR integrates **Swagger** for API documentation, making it easier to explore and test endpoints.  

## Changes  
- Installed and configured Swagger.  
- Added API documentation setup in `main.ts`.  
- Defined basic metadata.  

## Checklist  
- [x] Swagger UI loads correctly at `/docs`.  

## How to Test  
1. Run the application.  
2. Navigate to `http://localhost:<PORT>/docs`.  

