### PR TITLE
test(e2e): add end-to-end tests for auth, document, and ingestion

### DIFF
--- a/src/constants/app.constants.ts
+++ b/src/constants/app.constants.ts
@@ -4,4 +4,5 @@ export const APP_ROUTES = {
   USERS: 'users',
   FILES: 'files',
   DOCUMENTS: 'documents',
+  INGESTION: 'ingestion',
 };

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,221 @@
+import { type INestApplication } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { APP_ROUTES } from '../src/constants/app.constants';
+import { type LoginPayloadDto } from '../src/modules/auth/dto/login-response.dto';
+import { type UserRegisterDto } from '../src/modules/auth/dto/user-register.dto';
+import { type UserLoginDto } from '../src/modules/users/dto/user-login-dto';
+import { type HttpServer, type LoginResponse } from './types/test.types';
+
+describe('AuthController (e2e)', () => {
+  let app: INestApplication;
+  let accessToken: string;
+  let refreshToken: string;
+
+  const testUser: UserRegisterDto = {
+    email: 'test@example.com',
+    password: 'Test@123',
+    firstName: 'Test',
+    lastName: 'User',
+  };
+
+  const loginDto: UserLoginDto = {
+    email: 'test@example.com',
+    password: 'Test@123',
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /auth/register', () => {
+    it('should register a new user', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/register`)
+        .send(testUser)
+        .expect(200);
+    });
+
+    it('should not register user with existing email', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/register`)
+        .send(testUser)
+        .expect(400);
+    });
+
+    it('should not register with invalid email format', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/register`)
+        .send({
+          ...testUser,
+          email: 'invalid-email',
+        })
+        .expect(400);
+    });
+
+    it('should not register with weak password', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/register`)
+        .send({
+          ...testUser,
+          password: 'weak',
+        })
+        .expect(400);
+    });
+
+    it('should not register with missing required fields', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/register`)
+        .send({
+          email: 'test@example.com',
+          password: 'Test@123',
+        })
+        .expect(400);
+    });
+  });
+
+  describe('POST /auth/login', () => {
+    it('should login with valid credentials', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/login`)
+        .send(loginDto)
+        .expect(200)
+        .expect((res: LoginResponse) => {
+          expect(res.body).toHaveProperty('accessToken');
+          expect(res.body).toHaveProperty('refreshToken');
+          accessToken = res.body.accessToken;
+          refreshToken = res.body.refreshToken;
+        });
+    });
+
+    it('should not login with invalid credentials', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/login`)
+        .send({
+          email: 'test@example.com',
+          password: 'wrongpassword',
+        })
+        .expect(401);
+    });
+
+    it('should not login with non-existent email', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/login`)
+        .send({
+          email: 'nonexistent@example.com',
+          password: 'Test@123',
+        })
+        .expect(401);
+    });
+
+    it('should not login with malformed request body', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/login`)
+        .send({
+          email: 'test@example.com',
+        })
+        .expect(400);
+    });
+  });
+
+  describe('POST /auth/refresh', () => {
+    it('should refresh access token with valid refresh token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/refresh`)
+        .set('Authorization', `Bearer ${refreshToken}`)
+        .expect(200)
+        .expect((res: LoginResponse) => {
+          expect(res.body).toHaveProperty('accessToken');
+          expect(res.body).toHaveProperty('refreshToken');
+          accessToken = res.body.accessToken;
+          refreshToken = res.body.refreshToken;
+        });
+    });
+
+    it('should not refresh with invalid refresh token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/refresh`)
+        .set('Authorization', 'Bearer invalid_token')
+        .expect(401);
+    });
+
+    it('should not refresh without authorization header', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/refresh`)
+        .expect(401);
+    });
+
+    it('should not refresh with expired refresh token', async () => {
+      const newUser = {
+        ...testUser,
+        email: 'expired@example.com',
+      };
+      await request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/register`)
+        .send(newUser);
+
+      const loginResponse = await request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/login`)
+        .send({
+          email: 'expired@example.com',
+          password: 'Test@123',
+        });
+
+      const loginPayload = loginResponse.body as LoginPayloadDto;
+
+      await new Promise((resolve) => setTimeout(resolve, 3600000));
+
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/refresh`)
+        .set('Authorization', `Bearer ${loginPayload.refreshToken}`)
+        .expect(401);
+    });
+  });
+
+  describe('POST /auth/logout', () => {
+    it('should logout successfully with valid access token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/logout`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+    });
+
+    it('should not logout with invalid access token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/logout`)
+        .set('Authorization', 'Bearer invalid_token')
+        .expect(401);
+    });
+
+    it('should not logout without authorization header', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/logout`)
+        .expect(401);
+    });
+
+    it('should not be able to use refresh token after logout', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/refresh`)
+        .set('Authorization', `Bearer ${refreshToken}`)
+        .expect(401);
+    });
+
+    it('should not be able to use access token after logout', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.AUTH}/logout`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(401);
+    });
+  });
+});

--- a/test/documents.e2e-spec.ts
+++ b/test/documents.e2e-spec.ts
@@ -1,0 +1,163 @@
+import { type INestApplication } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { APP_ROUTES } from '../src/constants/app.constants';
+import {
+  type DocumentTestResponse,
+  type HttpServer,
+  type LoginResponse,
+} from './types/test.types';
+
+describe('DocumentsController (e2e)', () => {
+  let app: INestApplication;
+  let authToken: string;
+  let documentId: string;
+
+  const testUser = {
+    email: 'test@example.com',
+    password: 'Test@123',
+    firstName: 'Test',
+    lastName: 'User',
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    // Create a test user and get auth token
+    await request(app.getHttpServer() as HttpServer)
+      .post(`/${APP_ROUTES.AUTH}/register`)
+      .send(testUser);
+
+    const loginResponse = await request(app.getHttpServer() as HttpServer)
+      .post(`/${APP_ROUTES.AUTH}/login`)
+      .send({
+        email: testUser.email,
+        password: testUser.password,
+      });
+
+    const loginData = loginResponse.body as LoginResponse['body'];
+    authToken = loginData.accessToken;
+
+    // Create a test document
+    const documentResponse = await request(app.getHttpServer() as HttpServer)
+      .post(`/${APP_ROUTES.DOCUMENTS}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        name: 'Test Document',
+        description: 'Test Description',
+      });
+
+    const documentData = documentResponse.body as DocumentTestResponse['body'];
+    documentId = documentData.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /documents', () => {
+    it('should create a new document', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.DOCUMENTS}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          name: 'New Document',
+          description: 'New Description',
+        })
+        .expect(201)
+        .expect((res: DocumentTestResponse) => {
+          expect(res.body).toHaveProperty('id');
+          expect(res.body.name).toBe('New Document');
+          expect(res.body.description).toBe('New Description');
+        });
+    });
+
+    it('should not create document without auth token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.DOCUMENTS}`)
+        .send({
+          name: 'New Document',
+          description: 'New Description',
+        })
+        .expect(401);
+    });
+
+    it('should not create document with invalid auth token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.DOCUMENTS}`)
+        .set('Authorization', 'Bearer invalid_token')
+        .send({
+          name: 'New Document',
+          description: 'New Description',
+        })
+        .expect(401);
+    });
+
+    it('should not create document with missing required fields', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.DOCUMENTS}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          name: 'New Document',
+        })
+        .expect(400);
+    });
+  });
+
+  describe('GET /documents', () => {
+    it('should get all documents', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.DOCUMENTS}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res: DocumentTestResponse) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('should not get documents without auth token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.DOCUMENTS}`)
+        .expect(401);
+    });
+
+    it('should not get documents with invalid auth token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.DOCUMENTS}`)
+        .set('Authorization', 'Bearer invalid_token')
+        .expect(401);
+    });
+  });
+
+  describe('GET /documents/:id', () => {
+    it('should get document by id', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.DOCUMENTS}/${documentId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res: DocumentTestResponse) => {
+          expect(res.body.id).toBe(documentId);
+        });
+    });
+
+    it('should not get document with invalid id', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.DOCUMENTS}/invalid-id`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(404);
+    });
+
+    it('should not get document without auth token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.DOCUMENTS}/${documentId}`)
+        .expect(401);
+    });
+  });
+});

--- a/test/ingestion.e2e-spec.ts
+++ b/test/ingestion.e2e-spec.ts
@@ -1,0 +1,172 @@
+import { type INestApplication } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { APP_ROUTES } from '../src/constants/app.constants';
+import {
+  type HttpServer,
+  type IngestionTestResponse,
+  type LoginResponse,
+} from './types/test.types';
+
+describe('IngestionController (e2e)', () => {
+  let app: INestApplication;
+  let authToken: string;
+  let documentId: string;
+  let ingestionId: string;
+
+  const testUser = {
+    email: 'test@example.com',
+    password: 'Test@123',
+    firstName: 'Test',
+    lastName: 'User',
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    // Create a test user and get auth token
+    await request(app.getHttpServer() as HttpServer)
+      .post(`/${APP_ROUTES.AUTH}/register`)
+      .send(testUser);
+
+    const loginResponse = await request(app.getHttpServer() as HttpServer)
+      .post(`/${APP_ROUTES.AUTH}/login`)
+      .send({
+        email: testUser.email,
+        password: testUser.password,
+      });
+
+    const loginData = loginResponse.body as LoginResponse['body'];
+    authToken = loginData.accessToken;
+
+    // Create a test document
+    const documentResponse = await request(app.getHttpServer() as HttpServer)
+      .post(`/${APP_ROUTES.DOCUMENTS}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        name: 'Test Document',
+        description: 'Test Description',
+      });
+
+    const documentData = documentResponse.body as { id: string };
+    documentId = documentData.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /ingestion', () => {
+    it('should create a new ingestion', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.INGESTION}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          documentId,
+          file: {
+            buffer: Buffer.from('test content'),
+            originalname: 'test.txt',
+            mimetype: 'text/plain',
+          },
+        })
+        .expect(201)
+        .expect((res: IngestionTestResponse) => {
+          const ingestion = Array.isArray(res.body) ? res.body[0] : res.body;
+          expect(ingestion).toHaveProperty('id');
+          expect(ingestion).toHaveProperty('status');
+          expect(ingestion.document.id).toBe(documentId);
+          ingestionId = ingestion.id;
+        });
+    });
+
+    it('should not create ingestion without auth token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.INGESTION}`)
+        .send({
+          documentId,
+          file: {
+            buffer: Buffer.from('test content'),
+            originalname: 'test.txt',
+            mimetype: 'text/plain',
+          },
+        })
+        .expect(401);
+    });
+
+    it('should not create ingestion with invalid document id', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .post(`/${APP_ROUTES.INGESTION}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          documentId: 'invalid-id',
+          file: {
+            buffer: Buffer.from('test content'),
+            originalname: 'test.txt',
+            mimetype: 'text/plain',
+          },
+        })
+        .expect(404);
+    });
+  });
+
+  describe('GET /ingestion', () => {
+    it('should get all ingestions', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.INGESTION}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res: IngestionTestResponse) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('should not get ingestions without auth token', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.INGESTION}`)
+        .expect(401);
+    });
+  });
+
+  describe('GET /ingestion/:id', () => {
+    it('should get ingestion by id', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.INGESTION}/${ingestionId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res: IngestionTestResponse) => {
+          const ingestion = Array.isArray(res.body) ? res.body[0] : res.body;
+          expect(ingestion.id).toBe(ingestionId);
+        });
+    });
+
+    it('should not get ingestion with invalid id', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .get(`/${APP_ROUTES.INGESTION}/invalid-id`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(404);
+    });
+  });
+
+  describe('DELETE /ingestion/:id', () => {
+    it('should delete ingestion by id', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .delete(`/${APP_ROUTES.INGESTION}/${ingestionId}`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(204);
+    });
+
+    it('should not delete ingestion with invalid id', () => {
+      return request(app.getHttpServer() as HttpServer)
+        .delete(`/${APP_ROUTES.INGESTION}/invalid-id`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(404);
+    });
+  });
+});

--- a/test/types/test.types.ts
+++ b/test/types/test.types.ts
@@ -1,0 +1,31 @@
+import { type Server } from 'http';
+
+import { type LoginPayloadDto } from '../../src/modules/auth/dto/login-response.dto';
+
+export interface DocumentResponse {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface IngestionResponse {
+  id: string;
+  status: string;
+  document: {
+    id: string;
+  };
+  error?: string;
+}
+
+export interface TestResponse<T> {
+  body: T;
+  status: number;
+}
+
+export type LoginResponse = TestResponse<LoginPayloadDto>;
+export type DocumentTestResponse = TestResponse<DocumentResponse>;
+export type IngestionTestResponse = TestResponse<
+  IngestionResponse | IngestionResponse[]
+>;
+
+export type HttpServer = Server;


### PR DESCRIPTION
This PR introduces end-to-end (E2E) tests for the authentication, document, and ingestion modules to ensure proper functionality, integration, and reliability.  

## Changes Introduced  
- Added E2E tests for authentication flows (register, login, logout, refresh token)  
- Implemented tests for document CRUD operations  
- Covered ingestion API flows (create, update, delete, status checks)  

## Checklist  
- [x] Auth module E2E tests implemented and passing  
- [x] Document module E2E tests implemented and passing  
- [x] Ingestion module E2E tests implemented and passing  
- [x] No breaking changes introduced  

## How to Test  
1. Run the E2E test suite using the test command:  
   ```bash
   npm run test:e2e
   ```  

## Related Issues  