### PR TITLE
feat: add database role seeding functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "migration:run": "npm run typeorm -- --dataSource=src/database/data-source.ts migration:run",
     "migration:revert": "npm run typeorm -- --dataSource=src/database/data-source.ts migration:revert",
     "migration:show": "npm run typeorm -- --dataSource=src/database/data-source.ts migration:show",
+    "seed": "ts-node -r tsconfig-paths/register src/database/seeds/seed.ts",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/src/database/seeds/index.ts
+++ b/src/database/seeds/index.ts
@@ -1,0 +1,16 @@
+import { type DataSource } from 'typeorm';
+
+import { seedRoles } from './role.seed';
+
+export async function runSeeds(dataSource: DataSource): Promise<void> {
+  try {
+    console.log('Starting database seeds...');
+
+    await seedRoles(dataSource);
+
+    console.log('All seeds completed successfully');
+  } catch (error) {
+    console.error('Error running seeds:', error);
+    throw error;
+  }
+}

--- a/src/database/seeds/role.seed.ts
+++ b/src/database/seeds/role.seed.ts
@@ -1,0 +1,34 @@
+import { type DataSource } from 'typeorm';
+
+import { RoleType } from '../../common/types/role.type';
+import { RoleEntity } from '../entity/role.entity';
+
+export async function seedRoles(dataSource: DataSource): Promise<void> {
+  const roleRepository = dataSource.getRepository(RoleEntity);
+
+  const existingRoles = await roleRepository.find();
+  if (existingRoles.length > 0) {
+    console.log('Roles already exist, skipping seed...');
+    return;
+  }
+
+  const roles: Partial<RoleEntity>[] = [
+    {
+      id: RoleType.USER,
+      name: 'User',
+      description: 'Regular user with basic permissions',
+      isActive: true,
+      isDefault: true,
+    },
+    {
+      id: RoleType.ADMIN,
+      name: 'Admin',
+      description: 'Administrator with full permissions',
+      isActive: true,
+      isDefault: false,
+    },
+  ];
+
+  await roleRepository.save(roles);
+  console.log('Default roles seeded successfully');
+}

--- a/src/database/seeds/seed.ts
+++ b/src/database/seeds/seed.ts
@@ -1,0 +1,20 @@
+import { AppDataSource } from '../data-source';
+import { runSeeds } from './index';
+
+async function seed() {
+  try {
+    await AppDataSource.initialize();
+    console.log('Data Source has been initialized!');
+
+    await runSeeds(AppDataSource);
+
+    await AppDataSource.destroy();
+    console.log('Data Source has been destroyed!');
+    process.exit(0);
+  } catch (error) {
+    console.error('Error during seeding:', error);
+    process.exit(1);
+  }
+}
+
+void seed();


### PR DESCRIPTION
This PR introduces database seeding functionality to initialize the application with required default data, such as roles.

## Changes Made
- Added `seed.ts` script in `src/database/seeds/` for database seeding
- Added new npm command `seed` to package.json for running database seeds

## Testing
- [x] Verified seed script runs successfully
- [x] Confirmed database is properly initialized with seed data

## Checklist
- [x] Tested locally

## Related Issues